### PR TITLE
Fixed issue. Missing opening bracket... In templates march.html

### DIFF
--- a/app/templates/march.html
+++ b/app/templates/march.html
@@ -86,7 +86,7 @@
     <script src="../static/javascript/jquery.min.js"></script>
     <script src="../static/javascript/bootstrap.min.js"></script>
     <script type="text/javascript">
-      $(function()
+      $(function(){
       $(document).ready(function() {
 
             $("#month .divider").css("background-color", "white");


### PR DESCRIPTION
This is not a hoax. The code for controlling click events is copy-pasted INSIDE each template file, and yes, we have a template file for each month of the year... And of course there was a typo...

This explains why the application suddenly broke for everyone even on Master, on March 1st...   😂